### PR TITLE
mkl-dnn windows port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,13 +20,13 @@ set(PROJECT_NAME "Intel(R) MKL-DNN")
 set(PROJECT_FULL_NAME "Intel(R) Math Kernel Library for Deep Neural Networks (Intel(R) MKL-DNN)")
 set(PROJECT_VERSION, "0.7")
 
-set(LIB_NAME mkldnn)
-
 project(${PROJECT_NAME} C CXX)
 
+set(LIB_NAME mkldnn)
+
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
-    message(STATUS "CMAKE_BUILD_TYPE is unset, defaulting to Release")
-    set(CMAKE_BUILD_TYPE "Release")
+    set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+    message(STATUS "CMAKE_BUILD_TYPE is unset, defaulting to ${CMAKE_BUILD_TYPE}")
 endif()
 
 include("cmake/MKL.cmake")
@@ -55,19 +55,60 @@ if(UNIX OR APPLE)
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -z noexecstack -z relro -z now")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -z noexecstack -z relro -z now")
     endif()
+    set(CCXX_WARN_FLAGS "-Wall -Werror -Wno-unknown-pragmas")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CCXX_FLAGS} -std=c99")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CCXX_FLAGS} -std=c++11 -fvisibility-inlines-hidden")
+    set(CMAKE_CCXX_FLAGS "${CMAKE_CCXX_FLAGS} ${OPENMP_FLAGS} ${CCXX_WARN_FLAGS} -DMKLDNN_DLL -DMKLDNN_DLL_EXPORTS -fvisibility=internal")
+    set(OPENMP_FLAGS "-fopenmp")
+    if(HAVE_MKL)
+        set(CMAKE_C_CREATE_SHARED_LIBRARY_FORBIDDEN_FLAGS ${OPENMP_FLAGS})
+        set(CMAKE_CXX_CREATE_SHARED_LIBRARY_FORBIDDEN_FLAGS ${OPENMP_FLAGS})
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -liomp5 -Wl,--as-needed")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -liomp5 -Wl,--as-needed")
+    endif()
 endif()
 
-set(OPENMP_FLAGS "-fopenmp")
-if(HAVE_MKL)
-    set(CMAKE_C_CREATE_SHARED_LIBRARY_FORBIDDEN_FLAGS ${OPENMP_FLAGS})
-    set(CMAKE_CXX_CREATE_SHARED_LIBRARY_FORBIDDEN_FLAGS ${OPENMP_FLAGS})
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -liomp5 -Wl,--as-needed")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -liomp5 -Wl,--as-needed")
+if (WIN32)
+    # For windows builds we use the following defines in the code to implement windows specfic code:
+    # _WIN32: for everything that is windows platform specific (for example posix_memalign)
+    # _MSC_VER: for everything that is MSVC specific (if MSVC is used to compile)
+    # _WIN: to enable winabi64 calling in jit*
+    #
+    # We tested with vs2015 and Intel Compilter 17.0.
+    # While vs2015 works, it supports only openmp.v2 which does not support 'omp parallel collapse' 
+    # so we can't use openmp and need to operate sequential.
+    #
+    # To build with MSVC:
+    #   cmake ..  -A x64 -G "Visual Studio 14 2015"
+    # To build with Intel Compiler:
+    #   cmake .. -A x64 -G "Visual Studio 14 2015" -T "Intel C++ Compiler 17.0"
+    #
+
+    # defines for all windows builds
+	add_definitions(-DNOMINMAX -DWIN32 -DOS_WIN -D_MBCS -DWIN64 -DWIN32_LEAN_AND_MEAN -DNOGDI -D_WIN)
+    add_definitions(-DMKLDNN_DLL -DMKLDNN_DLL_EXPORTS)
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+        # defines for Intel compiler
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 /Qopenmp")
+    endif()
+
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+        # defines for msvc
+        add_definitions(/bigobj /nologo /EHsc /GF /FC /MP /Gm-)
+        add_definitions(/wd4267 /wd4244 /wd4800 /wd4805 /wd4002 /wd4003)
+    endif()
+
+    set (EXTERNAL_LIBS "${MKLROOT}/../compiler/lib/intel64_win/libiomp5md.lib")
+
+    # TODO: mkl-dnn jit allocates larger chunks of memory on stack (ie. 32k). On windows the
+    # default commited stack size is 4K needs to increase to 32k. For now do this with via
+    # linker ... need to find a better way of doing this.
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:1048576,32768")
+
+    # collect the final exe's and dll's in a single directory
+    set(dir ${CMAKE_CURRENT_BINARY_DIR})
+    set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${dir})
 endif()
-set(CCXX_WARN_FLAGS "-Wall -Werror -Wno-unknown-pragmas")
-set(CMAKE_CCXX_FLAGS "${CMAKE_CCXX_FLAGS} ${OPENMP_FLAGS} ${CCXX_WARN_FLAGS} -DMKLDNN_DLL -DMKLDNN_DLL_EXPORTS -fvisibility=internal")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CCXX_FLAGS} -std=c99")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CCXX_FLAGS} -std=c++11 -fvisibility-inlines-hidden")
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -xHOST")
@@ -78,6 +119,7 @@ enable_testing()
 include_directories(include)
 
 add_subdirectory(src)
+
 add_subdirectory(examples)
 add_subdirectory(tests)
 

--- a/cmake/MKL.cmake
+++ b/cmake/MKL.cmake
@@ -31,7 +31,6 @@ function(detect_mkl LIBNAME)
             set(MKLINC ${MKLINC} PARENT_SCOPE)
         endif()
     endif()
-
     get_filename_component(__mklinc_root "${MKLINC}" PATH)
     find_library(MKLLIB NAMES ${LIBNAME}
         PATHS   ${MKLROOT}/lib ${MKLROOT}/lib/intel64
@@ -48,8 +47,12 @@ function(detect_mkl LIBNAME)
     endif()
 endfunction()
 
+if (WIN32)
+detect_mkl("mkl_rt.lib")
+else()
 detect_mkl("libmklml_intel.so")
 detect_mkl("libmkl_rt.so")
+endif()
 
 set(FAIL_WITHOUT_MKL)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,6 +16,10 @@
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
+if (NOT WIN32)
+set(MATH_LIB "m")
+endif()
+
 add_executable(simple-net-c simple_net.c)
 set_property(TARGET simple-net-c PROPERTY C_STANDARD 99)
 target_link_libraries(simple-net-c ${LIB_NAME})
@@ -26,12 +30,13 @@ set_property(TARGET simple-net-cpp PROPERTY CXX_STANDARD 11)
 target_link_libraries(simple-net-cpp ${LIB_NAME})
 add_test(simple-net-cpp simple-net-cpp)
 
+
 add_executable(simple-training-net-c simple_training_net.c)
 set_property(TARGET simple-training-net-c PROPERTY C_STANDARD 99)
-target_link_libraries(simple-training-net-c ${LIB_NAME} m)
+target_link_libraries(simple-training-net-c ${LIB_NAME} ${MATH_LIB})
 add_test(simple-training-net-c simple-training-net-c)
 
 add_executable(simple-training-net-cpp simple_training_net.cpp)
 set_property(TARGET simple-training-net-cpp PROPERTY CXX_STANDARD 11)
-target_link_libraries(simple-training-net-cpp ${LIB_NAME} m)
+target_link_libraries(simple-training-net-cpp ${LIB_NAME} ${MATH_LIB})
 add_test(simple-training-net-cpp simple-training-net-cpp)

--- a/examples/simple_net.c
+++ b/examples/simple_net.c
@@ -39,7 +39,19 @@
 } while(0)
 
 void *aligned_malloc(size_t size, size_t alignment) {
+#ifdef _WIN32
+    return _aligned_malloc(size, alignment);
+#else
     return memalign(alignment, size);
+#endif
+}
+
+void aligned_free(void *p) {
+#ifdef _WIN32
+    _aligned_free(p);
+#else
+    free(p);
+#endif
 }
 
 static size_t product(int *arr, size_t size) {
@@ -409,8 +421,8 @@ mkldnn_status_t simple_net(){
     /* clean-up */
     mkldnn_stream_destroy(stream);
 
-    free(net_src);
-    free(net_dst);
+    aligned_free(net_src);
+    aligned_free(net_dst);
 
     mkldnn_primitive_destroy(conv_user_src_memory);
     mkldnn_primitive_destroy(conv_user_weights_memory);
@@ -422,24 +434,24 @@ mkldnn_status_t simple_net(){
     mkldnn_primitive_destroy(conv_reorder_weights);
     mkldnn_primitive_destroy(conv);
 
-    free(conv_weights);
-    free(conv_bias);
+    aligned_free(conv_weights);
+    aligned_free(conv_bias);
 
-    free(conv_src_buffer);
-    free(conv_weights_buffer);
-    free(conv_dst_buffer);
+    aligned_free(conv_src_buffer);
+    aligned_free(conv_weights_buffer);
+    aligned_free(conv_dst_buffer);
 
     mkldnn_primitive_destroy(relu_dst_memory);
     mkldnn_primitive_destroy(relu);
 
-    free(relu_dst_buffer);
+    aligned_free(relu_dst_buffer);
 
     mkldnn_primitive_destroy(lrn_scratch_memory);
     mkldnn_primitive_destroy(lrn_dst_memory);
     mkldnn_primitive_destroy(lrn);
 
-    free(lrn_scratch_buffer);
-    free(lrn_dst_buffer);
+    aligned_free(lrn_scratch_buffer);
+    aligned_free(lrn_dst_buffer);
 
     mkldnn_primitive_destroy(pool_user_dst_memory);
     mkldnn_primitive_destroy(pool_internal_dst_memory);
@@ -447,8 +459,8 @@ mkldnn_status_t simple_net(){
     mkldnn_primitive_destroy(pool_reorder_dst);
     mkldnn_primitive_destroy(pool);
 
-    free(pool_dst_buffer);
-    free(pool_indices_buffer);
+    aligned_free(pool_dst_buffer);
+    aligned_free(pool_indices_buffer);
 
     return mkldnn_success;
 }

--- a/examples/simple_net.cpp
+++ b/examples/simple_net.cpp
@@ -32,10 +32,10 @@ void simple_net(){
      * {batch, 3, 227, 227} (x) {96, 3, 11, 11} -> {batch, 96, 55, 55}
      * strides: {4, 4}
      */
-    memory::dims conv_src_tz = {batch, 3, 227, 227};
+    memory::dims conv_src_tz = {(int)batch, 3, 227, 227};
     memory::dims conv_weights_tz = {96, 3, 11, 11};
     memory::dims conv_bias_tz = {96};
-    memory::dims conv_dst_tz = {batch, 96, 55, 55};
+    memory::dims conv_dst_tz = {(int)batch, 96, 55, 55};
     memory::dims conv_strides = {4, 4};
     auto conv_padding = {0, 0};
 
@@ -141,7 +141,7 @@ void simple_net(){
      * kernel: {3, 3}
      * strides: {2, 2}
      */
-    memory::dims pool_dst_tz = {batch, 96, 27, 27};
+    memory::dims pool_dst_tz = {(int)batch, 96, 27, 27};
     memory::dims pool_kernel = {3, 3};
     memory::dims pool_strides = {2, 2};
     auto pool_padding = {0, 0};
@@ -183,10 +183,13 @@ void simple_net(){
 int main(int argc, char **argv) {
     try {
         simple_net();
+        std::cout << "passed" << std::endl;
     }
     catch(error& e) {
         std::cerr << "status: " << e.status << std::endl;
+#ifndef _WIN32
         std::cerr << "message: " << e.message << std::endl;
+#endif
     }
     return 0;
 }

--- a/examples/simple_training_net.c
+++ b/examples/simple_training_net.c
@@ -43,7 +43,19 @@
     } while (0)
 
 void *aligned_malloc(size_t size, size_t alignment) {
+#ifdef _WIN32
+    return _aligned_malloc(size, alignment);
+#else
     return memalign(alignment, size);
+#endif
+}
+
+void aligned_free(void *p) {
+#ifdef _WIN32
+    _aligned_free(p);
+#else
+    free(p);
+#endif
 }
 
 static size_t product(int *arr, size_t size)
@@ -814,8 +826,8 @@ mkldnn_status_t simple_net()
     /* Cleanup forward */
     mkldnn_stream_destroy(stream_fwd);
 
-    free(net_src);
-    free(net_dst);
+    aligned_free(net_src);
+    aligned_free(net_dst);
 
     mkldnn_primitive_destroy(conv_user_src_memory);
     mkldnn_primitive_destroy(conv_user_weights_memory);
@@ -827,24 +839,24 @@ mkldnn_status_t simple_net()
     mkldnn_primitive_destroy(conv_reorder_weights);
     mkldnn_primitive_destroy(conv);
 
-    free(conv_weights);
-    free(conv_bias);
+    aligned_free(conv_weights);
+    aligned_free(conv_bias);
 
-    free(conv_src_buffer);
-    free(conv_weights_buffer);
-    free(conv_dst_buffer);
+    aligned_free(conv_src_buffer);
+    aligned_free(conv_weights_buffer);
+    aligned_free(conv_dst_buffer);
 
     mkldnn_primitive_destroy(relu_dst_memory);
     mkldnn_primitive_destroy(relu);
 
-    free(relu_dst_buffer);
+    aligned_free(relu_dst_buffer);
 
     mkldnn_primitive_destroy(lrn_workspace_memory);
     mkldnn_primitive_destroy(lrn_dst_memory);
     mkldnn_primitive_destroy(lrn);
 
-    free(lrn_workspace_buffer);
-    free(lrn_dst_buffer);
+    aligned_free(lrn_workspace_buffer);
+    aligned_free(lrn_dst_buffer);
 
     mkldnn_primitive_destroy(pool_user_dst_memory);
     mkldnn_primitive_destroy(pool_internal_dst_memory);
@@ -852,8 +864,8 @@ mkldnn_status_t simple_net()
     mkldnn_primitive_destroy(pool_reorder_dst);
     mkldnn_primitive_destroy(pool);
 
-    free(pool_dst_buffer);
-    free(pool_workspace_buffer);
+    aligned_free(pool_dst_buffer);
+    aligned_free(pool_workspace_buffer);
 
     /* Cleanup backward */
     mkldnn_stream_destroy(stream_bwd);
@@ -864,19 +876,19 @@ mkldnn_status_t simple_net()
     mkldnn_primitive_destroy(pool_reorder_diff_dst);
     mkldnn_primitive_destroy(pool_bwd);
 
-    free(net_diff_dst);
-    free(pool_diff_dst_buffer);
-    free(pool_diff_src_buffer);
+    aligned_free(net_diff_dst);
+    aligned_free(pool_diff_dst_buffer);
+    aligned_free(pool_diff_src_buffer);
 
     mkldnn_primitive_destroy(lrn_diff_src_memory);
     mkldnn_primitive_destroy(lrn_bwd);
 
-    free(lrn_diff_src_buffer);
+    aligned_free(lrn_diff_src_buffer);
 
     mkldnn_primitive_destroy(relu_diff_src_memory);
     mkldnn_primitive_destroy(relu_bwd);
 
-    free(relu_diff_src_buffer);
+    aligned_free(relu_diff_src_buffer);
 
     mkldnn_primitive_destroy(conv_user_diff_weights_memory);
     mkldnn_primitive_destroy(conv_diff_bias_memory);
@@ -884,9 +896,9 @@ mkldnn_status_t simple_net()
     mkldnn_primitive_destroy(conv_reorder_diff_weights);
     mkldnn_primitive_destroy(conv_bwd_weights);
 
-    free(conv_diff_weights_buffer);
-    free(conv_diff_bias_buffer);
-    free(conv_user_diff_weights_buffer);
+    aligned_free(conv_diff_weights_buffer);
+    aligned_free(conv_diff_bias_buffer);
+    aligned_free(conv_user_diff_weights_buffer);
 
     return mkldnn_success;
 }

--- a/examples/simple_training_net.cpp
+++ b/examples/simple_training_net.cpp
@@ -38,10 +38,10 @@ void simple_net()
      * {batch, 3, 227, 227} (x) {96, 3, 11, 11} -> {batch, 96, 55, 55}
      * strides: {4, 4}
      */
-    memory::dims conv_src_tz = { batch, 3, 227, 227 };
+    memory::dims conv_src_tz = { (int)batch, 3L, 227, 227 };
     memory::dims conv_weights_tz = { 96, 3, 11, 11 };
     memory::dims conv_bias_tz = { 96 };
-    memory::dims conv_dst_tz = { batch, 96, 55, 55 };
+    memory::dims conv_dst_tz = { (int)batch, 96L, 55, 55 };
     memory::dims conv_strides = { 4, 4 };
     auto conv_padding = { 0, 0 };
 
@@ -176,7 +176,7 @@ void simple_net()
      * kernel: {3, 3}
      * strides: {2, 2}
      */
-    memory::dims pool_dst_tz = { batch, 96, 27, 27 };
+    memory::dims pool_dst_tz = { (int)batch, 96L, 27, 27 };
     memory::dims pool_kernel = { 3, 3 };
     memory::dims pool_strides = { 2, 2 };
     auto pool_padding = { 0, 0 };
@@ -454,7 +454,9 @@ int main(int argc, char **argv)
     catch (error &e)
     {
         std::cerr << "status: " << e.status << std::endl;
+#ifndef _WIN32
         std::cerr << "message: " << e.message << std::endl;
-    }
+#endif
+	}
     return 0;
 }

--- a/include/mkldnn.h
+++ b/include/mkldnn.h
@@ -43,6 +43,27 @@
 #   define MKLDNN_API
 #endif
 
+#if defined(_MSC_VER) // && !defined(__INTEL_COMPILER)
+#define PACKED
+#else
+#define PACKED __attribute__((__packed__))
+#endif
+
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+// since MSVC does not support variable length arrays, replace them
+// with a define. One can either use vectors or alloca to implement
+// VLA - for now use alloca
+//#define VARIABLE_LENGTH_ARRAY(variable_name, num_items, type) \
+//    std::vector<type> variable_name(num_items)
+
+#define VARIABLE_LENGTH_ARRAY(variable_name, num_items, type) \
+    type *variable_name = (type *)alloca(sizeof(type) * num_items)
+#else
+#define VARIABLE_LENGTH_ARRAY(variable_name, num_items, type) \
+    type variable_name[num_items]
+#endif
+
+
 #include "mkldnn_types.h"
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,10 +31,10 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/common
     ${CMAKE_CURRENT_SOURCE_DIR}/cpu/xbyak
     )
+
 add_library(${TARGET_NAME} SHARED ${HEADERS} ${SOURCES})
-target_link_libraries(${TARGET_NAME} ${${TARGET_NAME}_LINKER_LIBS})
+target_link_libraries(${TARGET_NAME} ${${TARGET_NAME}_LINKER_LIBS} ${EXTERNAL_LIBS})
 set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD 11)
 set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
-
 install(TARGETS ${TARGET_NAME} DESTINATION lib)
 install(FILES ${HEADERS} DESTINATION include)

--- a/src/common/memory_desc_wrapper.hpp
+++ b/src/common/memory_desc_wrapper.hpp
@@ -18,7 +18,6 @@
 #define MEMORY_DESC_WRAPPER_HPP
 
 #include <assert.h>
-
 #include "c_types_map.hpp"
 #include "nstl.hpp"
 #include "utils.hpp"
@@ -70,7 +69,6 @@ struct memory_desc_wrapper: public c_compatible {
                     oihw, ihwo, OIhw8i8o, OIhw8o8i, Ohwi8o, goihw, gOIhw8i8o,
                     gOIhw8o8i, blocked, nChw16c, OIhw16i16o, OIhw16o16i,
                     Ohwi16o, gOIhw16i16o, gOIhw16o16i));
-
         if (blocking_desc().offset_padding != 0) return 0;
 
         const auto &block_dims = blocking_desc().block_dims;
@@ -212,6 +210,14 @@ private:
         return size_t(xn)*blocking_desc().strides[0][sizeof...(args)] +
             _blk_off<Args...>(args...);
     }
+
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+	template<typename T>
+    inline size_t _blk_off(T xn) const {
+        return blocking_desc().offset_padding +
+            size_t(xn)*blocking_desc().strides[0][0];
+    }
+#endif
 };
 
 inline bool memory_desc_wrapper::is_dense(bool with_padding) const {

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -91,7 +91,11 @@ inline bool operator!=(const memory_desc_t &lhs, const memory_desc_t &rhs) {
 }
 
 inline memory_desc_t zero_md() {
+#if defined(_MSC_VER)
+    memory_desc_t zero = {};
+#else
     memory_desc_t zero({});
+#endif
     zero.primitive_kind = primitive_kind::memory;
     return zero;
 }

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -173,12 +173,19 @@ inline bool nd_iterator_step(U &x, const W &X, Args &&... tuple) {
 
 }
 
+#if defined(_WIN32)
+inline void* malloc(size_t size, int alignment) {
+	return _aligned_malloc(size, alignment);
+}
+inline void free(void* p) {	_aligned_free(p); }
+#else
 inline void* malloc(size_t size, int alignment) {
     void *ptr;
     int rc = ::posix_memalign(&ptr, alignment, size);
     return (rc == 0) ? ptr : 0;
 }
 inline void free(void* p) { ::free(p); }
+#endif
 
 struct c_compatible {
     enum { default_alignment = 64 };

--- a/src/cpu/cpu_simple_concat.hpp
+++ b/src/cpu/cpu_simple_concat.hpp
@@ -57,10 +57,10 @@ struct cpu_simple_concat_t: public c_compatible {
             const nstl::vector<cpu_memory_t::pd_t> &dst_pds_,
             cpu_primitive_t *concat) {
         const int num_arrs = src_pds_.size();
-        const data_t *input_ptrs[num_arrs];
-        data_t *output_ptrs[num_arrs];
-        size_t nelems_no_d0[num_arrs];
-        size_t is[num_arrs];
+        VARIABLE_LENGTH_ARRAY(input_ptrs, num_arrs, const data_t *);
+        VARIABLE_LENGTH_ARRAY(output_ptrs, num_arrs, const data_t *);
+        VARIABLE_LENGTH_ARRAY(nelems_no_d0, num_arrs, size_t);
+        VARIABLE_LENGTH_ARRAY(is, num_arrs, size_t);
 
         auto o_base_ptr = reinterpret_cast<data_t *>(concat->memory());
 
@@ -87,7 +87,7 @@ struct cpu_simple_concat_t: public c_compatible {
             for (int a = 0; a < num_arrs; ++a) {
                 /* do coping */
                 const data_t *i = &input_ptrs[a][is[a]*n];
-                data_t *o = &output_ptrs[a][os*n];
+                data_t *o = (data_t *)&output_ptrs[a][os*n];
                 for (size_t e = 0; e < nelems_no_d0[a]; ++e) o[e] = i[e];
             }
         }

--- a/src/cpu/cpu_simple_sum.hpp
+++ b/src/cpu/cpu_simple_sum.hpp
@@ -55,14 +55,14 @@ struct cpu_simple_sum_t: public c_compatible {
                         cpu_memory_t::pd_t &dst_pds_,
                         cpu_primitive_t *sum)
     {
-        const int num_arrs = src_pds_.size();
+        int num_arrs = src_pds_.size();
 
         auto output = reinterpret_cast<data_t *>(sum->memory());
         const memory_desc_wrapper o_d(&dst_pds_);
         output += o_d.blk_off(0);
         const size_t nelems = o_d.nelems();
 
-        const data_t *input_ptrs[num_arrs];
+        VARIABLE_LENGTH_ARRAY(input_ptrs, num_arrs, const data_t *);
         for (int a = 0; a < num_arrs; ++a) {
             const memory_desc_wrapper i_d(&src_pds_[a]);
 

--- a/src/cpu/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/jit_avx2_conv_kernel_f32.cpp
@@ -284,9 +284,9 @@ void jit_avx2_conv_fwd_kernel_f32::generate()
     mov(reg_kernel, ptr[this->param1 + GET_OFF(filt)]);
     if (jcp.with_bias)
         mov(reg_bias, ptr[this->param1 + GET_OFF(bias)]);
-    mov(reg_kh, ptr[this->param1 + GET_OFF(kh_padding)]);
     mov(reg_ci_flag, ptr[this->param1 + GET_OFF(ic_flag)]);
     mov(reg_oc_blocks, ptr[this->param1 + GET_OFF(oc_blocks)]);
+    mov(reg_kh, ptr[this->param1 + GET_OFF(kh_padding)]);
 
     int nb_oc_tail = jcp.nb_oc % jcp.nb_oc_blocking;
     const char *tail_label = ".tail";

--- a/src/cpu/jit_avx2_conv_kernel_f32.hpp
+++ b/src/cpu/jit_avx2_conv_kernel_f32.hpp
@@ -131,9 +131,10 @@ struct jit_avx2_conv_bwd_weights_kernel_f32: public jit_generator {
 private:
     using reg64_t = const Xbyak::Reg64;
     reg64_t reg_input = rax;
+    reg64_t b_ic = rcx;
+
     reg64_t reg_kernel = rdx;
     reg64_t reg_output = rsi;
-    reg64_t b_ic = rcx;
     reg64_t kj = r8;
     reg64_t reg_kh = r9;
     reg64_t reg_ur_w_trips = r10;

--- a/src/cpu/jit_avx2_convolution.cpp
+++ b/src/cpu/jit_avx2_convolution.cpp
@@ -46,7 +46,6 @@ void _jit_avx2_convolution_fwd_t<with_relu>::execute_forward() {
 
     int ocb_work = div_up(jcp.nb_oc, jcp.nb_oc_blocking);
     const size_t work_amount = jcp.mb * jcp.ngroups * ocb_work * jcp.oh;
-
     auto ker = [&](const int ithr, const int nthr) {
         size_t start{0}, end{0};
         balance211(work_amount, nthr, ithr, start, end);
@@ -62,13 +61,13 @@ void _jit_avx2_convolution_fwd_t<with_relu>::execute_forward() {
             nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ocbb, ocb_work,
                              oh, jcp.oh);
             for (size_t iwork = start; iwork < end; ++iwork) {
-                int ocb = ocbb * jcp.nb_oc_blocking;
+                int ocb = static_cast<int>(ocbb * jcp.nb_oc_blocking);
                 int ocb_num = jcp.nb_oc_blocking;
 
                 for (int icb = icbb; icb < icbb + icb_step; ++icb) {
                     jit_conv_call_s par_conv = {};
 
-                    const int ij = oh * jcp.stride_h;
+                    const int ij = static_cast<int>(oh * jcp.stride_h);
                     const int i_t_overflow = nstl::max(0, jcp.t_pad - ij);
                     const int i_b_overflow = nstl::max(jcp.ih,
                                         ij + jcp.kh - jcp.t_pad) - jcp.ih;
@@ -183,11 +182,11 @@ void jit_avx2_convolution_bwd_data_t::execute_backward_data() {
                         {
                             for (int b = 0; b < jcp.nb_ic_blocking; b++)
                             {
-                                int current_ic =
+                                int current_ic = static_cast<int>(
                                     (jcp.ic == 3 ? 0 : g * jcp.nb_ic)
-                                    + jcp.nb_ic_blocking * icbb + b;
+                                    + jcp.nb_ic_blocking * icbb + b);
                                 int current_idx =
-                                    diff_src_d.blk_off(n, current_ic, ih, iw);
+                                    static_cast<int>(diff_src_d.blk_off(n, current_ic, ih, iw));
                                 for (int v = 0; v < simd_w; v++)
                                     diff_src[current_idx + v] = 0.0;
                             }

--- a/src/cpu/jit_avx512_mic_gemm_f32.cpp
+++ b/src/cpu/jit_avx512_mic_gemm_f32.cpp
@@ -16,6 +16,7 @@
 
 #include <math.h>
 
+#include "mkldnn.h"
 #include "mkldnn_thread.hpp"
 #include "utils.hpp"
 
@@ -1962,7 +1963,12 @@ void jit_avx512_mic_gemm_f32::sgemm(const char *transa, const char *transb,
 
 #define CACHE_LINE_SIZE 16
 
+#if defined(_MSC_VER)
+    const int status_size = nthr * CACHE_LINE_SIZE;
+    VARIABLE_LENGTH_ARRAY(ompstatus, status_size, unsigned int);
+#else
     unsigned int __volatile__ ompstatus[nthr * CACHE_LINE_SIZE];
+#endif
     float *c_buffers = NULL;
 
     if (nthr_k > 1) {

--- a/src/cpu/jit_generator.hpp
+++ b/src/cpu/jit_generator.hpp
@@ -122,12 +122,15 @@ static inline bool mayiuse(const cpu_isa_t cpu_isa) {
         return cpu.has(Cpu::tSSE42);
     case avx2:
         return cpu.has(Cpu::tAVX2);
+#ifdef _WIN
+	// TODO: this path is not tested on windows
     case avx512_mic:
         return true
             && cpu.has(Cpu::tAVX512F)
             && cpu.has(Cpu::tAVX512CD)
             && cpu.has(Cpu::tAVX512ER)
             && cpu.has(Cpu::tAVX512PF);
+#endif
     }
     return false;
 }

--- a/src/cpu/jit_primitive_conf.hpp
+++ b/src/cpu/jit_primitive_conf.hpp
@@ -45,7 +45,11 @@ struct jit_conv_conf_t {
     bool is_1stconv;
 };
 
-struct __attribute__((__packed__)) jit_conv_call_s {
+
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#pragma pack(push,1)
+#endif
+struct PACKED jit_conv_call_s {
     const float *src; /* hack, non-const for backward_data */
     const float *dst; /* hack, non-const for forward */
     const float *filt; /* hack, non-const for backward_weights */
@@ -62,6 +66,9 @@ struct __attribute__((__packed__)) jit_conv_call_s {
     size_t oc_blocks;
     int ic_flag;
 };
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#pragma pack(pop)
+#endif
 
 struct jit_1x1_conv_conf_t {
     prop_kind_t prop_kind;
@@ -112,7 +119,10 @@ struct jit_gemm_conv_conf_t {
     size_t im2col_size;
 };
 
-struct __attribute__((__packed__)) jit_1x1_conv_call_s {
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#pragma pack(push,1)
+#endif
+struct PACKED jit_1x1_conv_call_s {
     const float *bcast_data;
     const float *load_data;
     const float *output_data;
@@ -126,6 +136,9 @@ struct __attribute__((__packed__)) jit_1x1_conv_call_s {
 
     size_t reduce_pos_flag;
 };
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#pragma pack(pop)
+#endif
 
 }
 }

--- a/src/cpu/jit_sse42_conv_kernel_f32.cpp
+++ b/src/cpu/jit_sse42_conv_kernel_f32.cpp
@@ -317,9 +317,9 @@ void jit_sse42_conv_fwd_kernel_f32::generate()
     mov(reg_kernel, ptr[this->param1 + GET_OFF(filt)]);
     if (jcp.with_bias)
         mov(reg_bias, ptr[this->param1 + GET_OFF(bias)]);
-    mov(reg_kh, ptr[this->param1 + GET_OFF(kh_padding)]);
     mov(reg_ci_flag, ptr[this->param1 + GET_OFF(ic_flag)]);
     mov(reg_oc_blocks, ptr[this->param1 + GET_OFF(oc_blocks)]);
+    mov(reg_kh, ptr[this->param1 + GET_OFF(kh_padding)]);
 
     int nb_oc_tail = jcp.nb_oc % jcp.nb_oc_blocking;
     const char *tail_label = ".tail";

--- a/src/cpu/jit_uni_pool_kernel_f32.hpp
+++ b/src/cpu/jit_uni_pool_kernel_f32.hpp
@@ -44,7 +44,10 @@ struct jit_pool_conf_t {
     int ur_w_tail;
 };
 
-struct __attribute__ ((__packed__)) jit_pool_call_s {
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#pragma pack(push,1)
+#endif
+struct PACKED jit_pool_call_s {
     const float *src;
     const float *dst;
     const int *indices;
@@ -56,6 +59,9 @@ struct __attribute__ ((__packed__)) jit_pool_call_s {
     size_t kw_padding;
     const float* init_value;
 };
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#pragma pack(pop)
+#endif
 
 template <cpu_isa_t isa>
 struct jit_uni_pool_kernel_f32: public jit_generator {

--- a/src/cpu/xbyak/xbyak_mnemonic.h
+++ b/src/cpu/xbyak/xbyak_mnemonic.h
@@ -410,6 +410,9 @@ void jnge(const Label& label, LabelType type = T_AUTO) { opJmp(label, type, 0x7C
 void jnge(const char *label, LabelType type = T_AUTO) { jnge(std::string(label), type); }
 void jnge(const void *addr) { opJmpAbs(addr, T_NEAR, 0x7C, 0x8C, 0x0F); }
 void jnge(std::string label, LabelType type = T_AUTO) { opJmp(label, type, 0x7C, 0x8C, 0x0F); }
+#if defined(_MSC_VER) && defined(__INTEL_COMPILER)
+#undef jnl
+#endif
 void jnl(const Label& label, LabelType type = T_AUTO) { opJmp(label, type, 0x7D, 0x8D, 0x0F); }
 void jnl(const char *label, LabelType type = T_AUTO) { jnl(std::string(label), type); }
 void jnl(const void *addr) { opJmpAbs(addr, T_NEAR, 0x7D, 0x8D, 0x0F); }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ set_property(TARGET api-c PROPERTY C_STANDARD 99)
 target_link_libraries(api-c ${LIB_NAME})
 add_test(api-c api-c)
 
+if(NOT WIN32)
 set(test_c_symbols "${CMAKE_CURRENT_BINARY_DIR}/test_c_symbols.c")
 add_executable(test_c_symbols-c ${test_c_symbols})
 add_custom_command(
@@ -40,9 +41,7 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/.. ${test_c_symbols}
 )
 target_link_libraries(test_c_symbols-c ${LIB_NAME})
-
 add_test(test_c_symbols-c test_c_symbols-c)
-
-
+endif()
 
 add_subdirectory(gtests)

--- a/tests/api.c
+++ b/tests/api.c
@@ -51,7 +51,7 @@ void test1() {
 
     const int len0 = 100;
     mkldnn_dims_t dims = {len0};
-    real_t data[len0];
+    real_t *data = malloc(sizeof(real_t) * len0);
 
     mkldnn_memory_desc_t md;
     mkldnn_primitive_desc_t mpd;

--- a/tests/gtests/convolution_common.h
+++ b/tests/gtests/convolution_common.h
@@ -16,8 +16,14 @@
 *******************************************************************************/
 #endif
 
+#ifdef _MSC_VER
+#define EXPAND_SIZES_(mb, ng, ic, ih, iw, oc, oh, ow, kh, kw, ph, pw, sh, sw) \
+    { mb, ng, ic, ih, iw, oc, oh, ow, kh, kw, ph, pw, sh, sw }
+#define EXPAND_SIZES(x) x
+#else
 #define EXPAND_SIZES(mb, ng, ic, ih, iw, oc, oh, ow, kh, kw, ph, pw, sh, sw) \
     { mb, ng, ic, ih, iw, oc, oh, ow, kh, kw, ph, pw, sh, sw }
+#endif
 #define EXPAND_FORMATS(src, weights, bias, dst) \
     { memory::format::src, memory::format::weights, \
     memory::format::bias, memory::format::dst }

--- a/tests/gtests/test_batch_normalization.cpp
+++ b/tests/gtests/test_batch_normalization.cpp
@@ -389,7 +389,12 @@ TEST_P(bnrm_test_float, TestsBnrm)
 {
 }
 
+#ifdef _MSC_VER
+#define EXPAND_SIZES(x) x
+#define EXPAND_SIZES_(mb, c, h, w) { mb, c, h, w }
+#else
 #define EXPAND_SIZES(mb, c, h, w) { mb, c, h, w }
+#endif
 #define EXPAND_FORMATS(data, diff) \
     { memory::format::data, memory::format::diff }
 


### PR DESCRIPTION
Initial cut at mkl-dnn windows port.
Both msvc and intel compiler build and pass unittest but because of the missing openmp v3
support in msvc we can not enable openmp.

Issues: the unittest test_convolution_backward_data
BackwardData_SimpleSmall_Blocked/convolution_test.TestConvolution/5 is flaky.

Most of the port deals with the following:
1. win64abi
2. windows platform specific functions, like posix_memalign
3. msvc specifics

We have tested sse4 and avx2. 
Performance looks similar to linux for unittests.