### PR TITLE
More type conversion stuff.

### DIFF
--- a/include/mkldnn.hpp
+++ b/include/mkldnn.hpp
@@ -387,7 +387,7 @@ struct memory: public primitive  {
                 format aformat) {
             validate_dims(adims);
             error::wrap_c_api(
-                    c_api::mkldnn_memory_desc_init(&data, adims.size(),
+                    c_api::mkldnn_memory_desc_init(&data, (int)adims.size(),
                         adims.size() == 0 ? nullptr : &adims[0],
                          convert_to_c(adata_type), convert_to_c(aformat)),
                     "could not initialize a memory descriptor");
@@ -673,7 +673,7 @@ struct concat : public primitive {
             auto c_api_inputs = cpp_to_c(inputs);
 
             error::wrap_c_api(c_api::mkldnn_concat_primitive_desc_create(
-                    &result, &output.data, c_api_inputs.size(),
+                    &result, &output.data, (int)c_api_inputs.size(),
                     concat_dimension, &c_api_inputs[0]),
                 "could not create a concat primitive descriptor");
             reset(result);
@@ -686,8 +686,8 @@ struct concat : public primitive {
             auto c_api_inputs = cpp_to_c(inputs);
 
             error::wrap_c_api(c_api::mkldnn_concat_primitive_desc_create(
-                    &result, nullptr, c_api_inputs.size(), concat_dimension,
-                    &c_api_inputs[0]),
+                    &result, nullptr, (int)c_api_inputs.size(),
+                    concat_dimension, &c_api_inputs[0]),
                 "could not create a concat primitive descriptor");
             reset(result);
         }
@@ -742,7 +742,7 @@ struct sum : public primitive {
             auto c_api_inputs = cpp_to_c(inputs);
 
             error::wrap_c_api(c_api::mkldnn_sum_primitive_desc_create(
-                    &result, &output.data, c_api_inputs.size(),
+                    &result, &output.data, (int)c_api_inputs.size(),
                     &scale[0], &c_api_inputs[0]),
                 "could not create a sum primitive descriptor");
             reset(result);
@@ -755,7 +755,7 @@ struct sum : public primitive {
             auto c_api_inputs = cpp_to_c(inputs);
 
             error::wrap_c_api(c_api::mkldnn_sum_primitive_desc_create(
-                    &result, nullptr, c_api_inputs.size(), &scale[0],
+                    &result, nullptr, (int)c_api_inputs.size(), &scale[0],
                     &c_api_inputs[0]),
                 "could not create a sum primitive descriptor");
             reset(result);

--- a/src/cpu/cpu_simple_concat.hpp
+++ b/src/cpu/cpu_simple_concat.hpp
@@ -51,7 +51,8 @@ struct cpu_simple_concat_t: public c_compatible {
             ok = ok && i_d.data_type() == data_type
                 && o_d.data_type() == data_type && i_d.format() == o_d.format()
                 && is_dense_no_0(i_d) && is_dense_no_0(o_d)
-                && (src_pds_.size()==0 || i_d.blocking_desc().strides[0][0] > 0);
+                && (src_pds_.size() == 0 ||
+                        i_d.blocking_desc().strides[0][0] > 0);
         }
         return ok;
     }
@@ -59,7 +60,7 @@ struct cpu_simple_concat_t: public c_compatible {
     static void execute(const nstl::vector<cpu_memory_t::pd_t> &src_pds_,
             const nstl::vector<cpu_memory_t::pd_t> &dst_pds_,
             cpu_primitive_t *concat) {
-        const int num_arrs = int(src_pds_.size()); // safe because <= max_num_arrs
+        const int num_arrs = int(src_pds_.size()); // safe (<= max_num_arrs)
         const data_t *input_ptrs[max_num_arrs];
         data_t *output_ptrs[max_num_arrs];
         size_t nelems_no_d0[max_num_arrs];
@@ -80,17 +81,17 @@ struct cpu_simple_concat_t: public c_compatible {
         }
 
         const memory_desc_wrapper o_d(&dst_pds_[0]);
-        const size_t N = o_d.dims()[0];
+        const int N = o_d.dims()[0];
         const size_t os = size_t(o_d.blocking_desc().strides[0][0]);
 
         catch_me();
 
 #       pragma omp parallel for collapse(2) schedule(static)
-        for (size_t n = 0; n < N; ++n) {
+        for (int n = 0; n < N; ++n) {
             for (int a = 0; a < num_arrs; ++a) {
                 /* do coping */
-                const data_t *i = &input_ptrs[a][is[a]*n];
-                data_t *o = &output_ptrs[a][os*n];
+                const data_t *i = &input_ptrs[a][is[a] * size_t(n)];
+                data_t *o = &output_ptrs[a][os * size_t(n)];
                 for (size_t e = 0; e < nelems_no_d0[a]; ++e) o[e] = i[e];
             }
         }

--- a/src/cpu/cpu_simple_concat.hpp
+++ b/src/cpu/cpu_simple_concat.hpp
@@ -59,7 +59,7 @@ struct cpu_simple_concat_t: public c_compatible {
     static void execute(const nstl::vector<cpu_memory_t::pd_t> &src_pds_,
             const nstl::vector<cpu_memory_t::pd_t> &dst_pds_,
             cpu_primitive_t *concat) {
-        const int num_arrs = int(src_pds_.size());
+        const int num_arrs = int(src_pds_.size()); // safe because <= max_num_arrs
         const data_t *input_ptrs[max_num_arrs];
         data_t *output_ptrs[max_num_arrs];
         size_t nelems_no_d0[max_num_arrs];
@@ -87,7 +87,7 @@ struct cpu_simple_concat_t: public c_compatible {
 
 #       pragma omp parallel for collapse(2) schedule(static)
         for (size_t n = 0; n < N; ++n) {
-            for (size_t a = 0; a < num_arrs; ++a) {
+            for (int a = 0; a < num_arrs; ++a) {
                 /* do coping */
                 const data_t *i = &input_ptrs[a][is[a]*n];
                 data_t *o = &output_ptrs[a][os*n];

--- a/src/cpu/cpu_simple_concat.hpp
+++ b/src/cpu/cpu_simple_concat.hpp
@@ -50,7 +50,8 @@ struct cpu_simple_concat_t: public c_compatible {
             const memory_desc_wrapper o_d(&dst_pds_[i]);
             ok = ok && i_d.data_type() == data_type
                 && o_d.data_type() == data_type && i_d.format() == o_d.format()
-                && is_dense_no_0(i_d) && is_dense_no_0(o_d);
+                && is_dense_no_0(i_d) && is_dense_no_0(o_d)
+                && (src_pds_.size()==0 || i_d.blocking_desc().strides[0][0] > 0);
         }
         return ok;
     }
@@ -58,7 +59,7 @@ struct cpu_simple_concat_t: public c_compatible {
     static void execute(const nstl::vector<cpu_memory_t::pd_t> &src_pds_,
             const nstl::vector<cpu_memory_t::pd_t> &dst_pds_,
             cpu_primitive_t *concat) {
-        const int num_arrs = src_pds_.size();
+        const int num_arrs = int(src_pds_.size());
         const data_t *input_ptrs[max_num_arrs];
         data_t *output_ptrs[max_num_arrs];
         size_t nelems_no_d0[max_num_arrs];
@@ -75,18 +76,18 @@ struct cpu_simple_concat_t: public c_compatible {
             output_ptrs[a] = o_base_ptr + o_d.blk_off(0);
 
             nelems_no_d0[a] = nelems_no_dim_0(i_d);
-            is[a] = i_d.blocking_desc().strides[0][0];
+            is[a] = size_t(i_d.blocking_desc().strides[0][0]);
         }
 
         const memory_desc_wrapper o_d(&dst_pds_[0]);
         const size_t N = o_d.dims()[0];
-        const size_t os = o_d.blocking_desc().strides[0][0];
+        const size_t os = size_t(o_d.blocking_desc().strides[0][0]);
 
         catch_me();
 
 #       pragma omp parallel for collapse(2) schedule(static)
-        for (int n = 0; n < N; ++n) {
-            for (int a = 0; a < num_arrs; ++a) {
+        for (size_t n = 0; n < N; ++n) {
+            for (size_t a = 0; a < num_arrs; ++a) {
                 /* do coping */
                 const data_t *i = &input_ptrs[a][is[a]*n];
                 data_t *o = &output_ptrs[a][os*n];

--- a/src/cpu/cpu_simple_sum.hpp
+++ b/src/cpu/cpu_simple_sum.hpp
@@ -71,7 +71,7 @@ struct cpu_simple_sum_t: public c_compatible {
                     sum->input_memory(a)) + i_d.blk_off(0);
         }
 
-        unsigned block_size =  int(16 * 1024/sizeof(data_type));
+        const size_t block_size = 16 * 1024 / sizeof(data_type);
         const size_t blocks_number = nelems / block_size;
         const size_t tail = nelems % block_size;
 
@@ -86,11 +86,11 @@ struct cpu_simple_sum_t: public c_compatible {
                 size_t start_e = nb * block_size;
                 size_t end_e = start_e + block_size;
                 for (size_t e = start_e; e < end_e; e++) {
-                    output[e] = static_cast<data_t>(scale_[0] * input_ptrs[0][e]);
+                    output[e] = data_t(scale_[0] * input_ptrs[0][e]);
                 }
                 for (int a = 1; a < num_arrs; a++) {
                     for (size_t e = start_e; e < end_e; e++) {
-                        output[e] += static_cast<data_t>(scale_[a] * input_ptrs[a][e]);
+                        output[e] += data_t(scale_[a] * input_ptrs[a][e]);
                     }
                 }
             }
@@ -99,11 +99,11 @@ struct cpu_simple_sum_t: public c_compatible {
                 size_t start_e = nelems - tail;
                 size_t end_e = nelems;
                 for (size_t e = start_e; e < end_e; e++) {
-                    output[e] = static_cast<data_t>(scale_[0] * input_ptrs[0][e]);
+                    output[e] = data_t(scale_[0] * input_ptrs[0][e]);
                 }
                 for (int a = 1; a < num_arrs; a++) {
                     for (size_t e = start_e; e < end_e; e++) {
-                        output[e] += static_cast<data_t>(scale_[a] * input_ptrs[a][e]);
+                        output[e] += data_t(scale_[a] * input_ptrs[a][e]);
                     }
                 }
             }

--- a/src/cpu/cpu_simple_sum.hpp
+++ b/src/cpu/cpu_simple_sum.hpp
@@ -83,13 +83,13 @@ struct cpu_simple_sum_t: public c_compatible {
             balance211(blocks_number, nthr, ithr, start, end);
 
             for (size_t nb = start; nb < end; ++nb) {
-                int start_e = nb * block_size;
-                int end_e = start_e + block_size;
-                for (int e = start_e; e < end_e; e++) {
+                size_t start_e = nb * block_size;
+                size_t end_e = start_e + block_size;
+                for (size_t e = start_e; e < end_e; e++) {
                     output[e] = static_cast<data_t>(scale_[0] * input_ptrs[0][e]);
                 }
                 for (int a = 1; a < num_arrs; a++) {
-                    for (int e = start_e; e < end_e; e++) {
+                    for (size_t e = start_e; e < end_e; e++) {
                         output[e] += static_cast<data_t>(scale_[a] * input_ptrs[a][e]);
                     }
                 }
@@ -98,11 +98,11 @@ struct cpu_simple_sum_t: public c_compatible {
             if (tail != 0 && ithr == nthr - 1) {
                 size_t start_e = nelems - tail;
                 size_t end_e = nelems;
-                for (int e = start_e; e < end_e; e++) {
+                for (size_t e = start_e; e < end_e; e++) {
                     output[e] = static_cast<data_t>(scale_[0] * input_ptrs[0][e]);
                 }
                 for (int a = 1; a < num_arrs; a++) {
-                    for (int e = start_e; e < end_e; e++) {
+                    for (size_t e = start_e; e < end_e; e++) {
                         output[e] += static_cast<data_t>(scale_[a] * input_ptrs[a][e]);
                     }
                 }

--- a/src/cpu/cpu_simple_sum.hpp
+++ b/src/cpu/cpu_simple_sum.hpp
@@ -56,7 +56,7 @@ struct cpu_simple_sum_t: public c_compatible {
                         cpu_memory_t::pd_t &dst_pds_,
                         cpu_primitive_t *sum)
     {
-        const int num_arrs = src_pds_.size();
+        const int num_arrs = int(src_pds_.size());
 
         auto output = reinterpret_cast<data_t *>(sum->memory());
         const memory_desc_wrapper o_d(&dst_pds_);
@@ -71,9 +71,9 @@ struct cpu_simple_sum_t: public c_compatible {
                     sum->input_memory(a)) + i_d.blk_off(0);
         }
 
-        int block_size =  16 * 1024/sizeof(data_type);
+        unsigned block_size =  int(16 * 1024/sizeof(data_type));
         const size_t blocks_number = nelems / block_size;
-        int tail = nelems % block_size;
+        const size_t tail = nelems % block_size;
 
 #pragma omp parallel
         {
@@ -86,24 +86,24 @@ struct cpu_simple_sum_t: public c_compatible {
                 int start_e = nb * block_size;
                 int end_e = start_e + block_size;
                 for (int e = start_e; e < end_e; e++) {
-                    output[e] = scale_[0] * input_ptrs[0][e];
+                    output[e] = static_cast<data_t>(scale_[0] * input_ptrs[0][e]);
                 }
                 for (int a = 1; a < num_arrs; a++) {
                     for (int e = start_e; e < end_e; e++) {
-                        output[e] += scale_[a] * input_ptrs[a][e];
+                        output[e] += static_cast<data_t>(scale_[a] * input_ptrs[a][e]);
                     }
                 }
             }
 
             if (tail != 0 && ithr == nthr - 1) {
-                int start_e = nelems - tail;
-                int end_e = nelems;
+                size_t start_e = nelems - tail;
+                size_t end_e = nelems;
                 for (int e = start_e; e < end_e; e++) {
-                    output[e] = scale_[0] * input_ptrs[0][e];
+                    output[e] = static_cast<data_t>(scale_[0] * input_ptrs[0][e]);
                 }
                 for (int a = 1; a < num_arrs; a++) {
                     for (int e = start_e; e < end_e; e++) {
-                        output[e] += scale_[a] * input_ptrs[a][e];
+                        output[e] += static_cast<data_t>(scale_[a] * input_ptrs[a][e]);
                     }
                 }
             }

--- a/src/cpu/gemm_convolution.hpp
+++ b/src/cpu/gemm_convolution.hpp
@@ -325,7 +325,7 @@ struct _gemm_convolution_bwd_weights_t: public cpu_primitive_t {
         jit_gemm_convolution_utils::init_conf(conf_.jcp_,
             *(conf_.desc()), conf_.src_pd(), conf_.diff_weights_pd(0),
             conf_.diff_dst_pd());
-          const memory_desc_wrapper weights_d(conf_.diff_weights_pd(0));
+        const memory_desc_wrapper weights_d(conf_.diff_weights_pd(0));
         jit_gemm_convolution_utils::prepare_workspace(this->conf_.jcp_,
             &this->ws, true, weights_d.size());
     }

--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -141,14 +141,14 @@ void init_conf(
 status_t prepare_workspace(
         jit_gemm_conv_conf_t &jcp, float **ws, bool is_bwd_weights,
         const size_t weights_size) {
-    const int nthr = omp_get_max_threads();
+    const size_t nthr = omp_get_max_threads();
     if (jcp.need_im2col) {
         const size_t sz_per_thread = jcp.ic*jcp.ks*jcp.os;
-        jcp.im2col_size = utils::rnd_up((size_t)nthr*sz_per_thread, 16);
+        jcp.im2col_size = utils::rnd_up(nthr*sz_per_thread, 16);
     } else {
         jcp.im2col_size = 0;
     }
-    int weights_reduce_size = 0;
+    size_t weights_reduce_size = 0;
     if (is_bwd_weights && jcp.mb != 1 && nthr != 1) {
         const size_t sz_per_thread = jcp.ngroups * weights_size;
         weights_reduce_size = nthr * sz_per_thread;

--- a/src/cpu/ref_batch_normalization.cpp
+++ b/src/cpu/ref_batch_normalization.cpp
@@ -80,7 +80,7 @@ void ref_batch_normalization_fwd_t<data_type>::execute_forward() {
             }
             v_variance /= W*H*N;
         }
-        sqrt_variance = 1. / sqrt(v_variance + eps);
+        sqrt_variance = static_cast<data_t>(1. / sqrt(v_variance + eps));
 
         if (use_scaleshift) {
             for (int n = 0; n < N; ++n)
@@ -143,7 +143,7 @@ void ref_batch_normalization_bwd_t<data_type>::execute_backward() {
     for (int c = 0; c < C; ++c) {
         data_t v_mean = mean[mean_d.off(c)];
         data_t v_variance = variance[variance_d.off(c)];
-        data_t sqrt_variance = 1. / sqrt(v_variance + eps);
+        data_t sqrt_variance = static_cast<data_t>(1. / sqrt(v_variance + eps));
         data_t gamma = use_scaleshift ? scaleshift[scaleshift_d.off(0, c)] : 1;
         data_t diff_gamma = data_t(0);
         data_t diff_beta = data_t(0);

--- a/src/cpu/ref_eltwise.cpp
+++ b/src/cpu/ref_eltwise.cpp
@@ -51,7 +51,7 @@ template <typename T, typename A> T elu_fwd(T s, A alpha) {
     return s > 0 ? s : static_cast<T>(alpha * (::expf((float)s) - 1.f));
 }
 template <typename T, typename A> T elu_bwd(T dd, T s, A alpha) {
-    return dd * (s > 0 ? T{1} : static_cast<T>(alpha * ::expf((float)s)));
+    return static_cast<T>(dd * (s > 0 ? 1 : alpha * ::expf((float)s)));
 }
 }
 

--- a/src/cpu/ref_eltwise.cpp
+++ b/src/cpu/ref_eltwise.cpp
@@ -37,13 +37,12 @@ template <typename T, typename A> inline T relu_bwd(T dd, T s, A alpha) {
 }
 
 template <typename T> T tanh_fwd(T s) {
-    float const e = ::expf(2*s); /* maybe replace with -2*s? */
+    const float e = ::expf(2*s); /* maybe replace with -2*s? */
     return static_cast<T>((e - 1) / (e + 1));
 }
 template <typename T> T tanh_bwd(T dd, T s) {
-    //T th = tanh_fwd(s);
-    float const e = ::expf(2*s); /* maybe replace with -2*s? */
-    float const th = (e - 1.f) / (e + 1.f);
+    const float e = ::expf(2*s); /* maybe replace with -2*s? */
+    const float th = (e - 1.f) / (e + 1.f);
     return static_cast<T>(dd * (1 - th * th));
 }
 

--- a/src/cpu/ref_lrn.cpp
+++ b/src/cpu/ref_lrn.cpp
@@ -29,6 +29,8 @@ namespace cpu {
 template <impl::data_type_t data_type>
 void ref_lrn_fwd_t<data_type>::execute_forward() {
     using namespace alg_kind;
+    typedef float float_t;    // foo_traits<data_type>::float_t;
+    typedef double accsqr_t;  // foo_traits<data_type>::accsqr_t; //float may be OK for f32
 
     auto src = reinterpret_cast<const data_t *>(this->input_memory(0));
     auto dst = reinterpret_cast<data_t*>(this->memory(0));
@@ -44,14 +46,14 @@ void ref_lrn_fwd_t<data_type>::execute_forward() {
 
     auto ker = [=](data_t *d, int mb, int oc, int oh, int ow) {
         const double alpha = conf_.desc()->lrn_alpha;
-        const double beta = conf_.desc()->lrn_beta;
+        const float beta = static_cast<float>(conf_.desc()->lrn_beta);
         const double k = conf_.desc()->lrn_k;
 
         const int size = conf_.desc()->local_size;
         const int CSIZE = across_channels ? size : 1;
         const int HWSIZE = size + 1 - CSIZE;
 
-        data_t sum = 0.0;
+        accsqr_t sum = 0;
         int summands = across_channels ? size : size*size;
         for (int c = oc; c < oc + CSIZE; ++c) {
             if (c < (CSIZE - 1) / 2) continue;
@@ -62,16 +64,18 @@ void ref_lrn_fwd_t<data_type>::execute_forward() {
                 for (int w = ow; w < ow + HWSIZE; ++w) {
                     if (w < (HWSIZE - 1) / 2) continue;
                     if (w >= W + (HWSIZE - 1) / 2) continue;
-                    data_t s = src[data_d.off(mb, c - (CSIZE - 1) / 2,
+                    accsqr_t s = src[data_d.off(mb, c - (CSIZE - 1) / 2,
                             h - (HWSIZE - 1) / 2, w - (HWSIZE - 1) / 2)];
                     sum += s * s;
                 }
             }
         }
-        sum = k + alpha * sum / summands;
+        const double fsum = k + alpha * sum / summands;
+        const data_t dsum = static_cast<data_t>(fsum);
         if (ws)
-            ws[ws_d.off(mb, oc, oh, ow)] = sum; // for back prop
-        d[0] = src[data_d.off(mb, oc, oh, ow)] / pow(sum, beta);
+            ws[ws_d.off(mb, oc, oh, ow)] = dsum; // for back prop (ok for integer data_t?)
+        d[0] = static_cast<data_t>( src[data_d.off(mb, oc, oh, ow)]
+                                    / powf((float)dsum, beta) );
     };
 
     const int MB = conf_.MB();
@@ -90,6 +94,8 @@ void ref_lrn_fwd_t<data_type>::execute_forward() {
 template <impl::data_type_t data_type>
 void ref_lrn_bwd_t<data_type>::execute_backward() {
     using namespace alg_kind;
+    typedef float float_t;    // foo_traits<data_type>::float_t;
+    typedef double accsqr_t;  // foo_traits<data_type>::accsqr_t; //float may be OK for f32
 
     auto src = reinterpret_cast<const data_t *>(this->input_memory(0));
     auto diff_dst = reinterpret_cast<const data_t *>(this->input_memory(1));
@@ -105,48 +111,48 @@ void ref_lrn_bwd_t<data_type>::execute_backward() {
     const int H = conf_.H();
     const int W = conf_.W();
 
-    const double alpha = conf_.desc()->lrn_alpha;
-    const double beta = conf_.desc()->lrn_beta;
-    const double k = conf_.desc()->lrn_k;
+    const float_t alpha = static_cast<float_t>(conf_.desc()->lrn_alpha);
+    const float_t beta = static_cast<float_t>(conf_.desc()->lrn_beta);
+    const float_t k = static_cast<float_t>(conf_.desc()->lrn_k);
     const int kernel_size = conf_.desc()->local_size;
 
     auto get_omega = [=](data_t c_k, int kernel_size, double alpha, int C,
-            const data_t *src, int n, int c, int h, int w) {
-        data_t sum = 0.0;
+            const data_t *src, int n, int c, int h, int w) -> float_t {
+        accsqr_t sum = 0.0;
 
         int half_kernel_size = (kernel_size - 1) / 2;
         int c_start = (c < half_kernel_size) ? 0 : c - half_kernel_size;
         int c_end = c + kernel_size - half_kernel_size;
         c_end = c_end < C ? c_end : C;
         for (int i = c_start; i < c_end; ++i) {
-            data_t value = src[data_d.off(n, i, h, w)];
+            const accsqr_t value = src[data_d.off(n, i, h, w)];
             sum += value * value;
         }
-        sum *= alpha / kernel_size;
-        return c_k + sum;
+        const auto fsum = sum * alpha / kernel_size;
+        return static_cast<float_t>(c_k + fsum);
     };
 
     auto ker = [=](data_t *d, int mb, int oc, int oh, int ow) {
         int ks_start = kernel_size/2 > oc ? kernel_size/2 - oc : 0;
         int ks_stop = C - oc <= kernel_size/2 ? C - oc + kernel_size/2 : kernel_size;
 
-        data_t A = 0, B = 0, omega_mid = 0;
-
+        float_t A = 0, B = 0, omega_mid = 0;
+        // intermediate calcs data_t --> float_t : check if OK for integer data_t!
         for (int ks = ks_start; ks < ks_stop; ks++) {
             int _t = oc + ks - (kernel_size/2);
-            data_t omega = get_omega(k, kernel_size, alpha, C,
+            const float_t omega = get_omega(k, kernel_size, alpha, C,
                     src, mb, _t, oh, ow);
 
             if (ks == kernel_size/2) omega_mid = omega;
 
-            data_t t = src[data_d.off(mb, _t, oh, ow)] / powf(omega, beta);
+            const float_t t = src[data_d.off(mb, _t, oh, ow)] / powf(omega, beta);
             B +=  (1.0f / omega) * t * diff_dst[diff_data_d.off(mb, _t, oh, ow)];
         }
 
         A = (1.0f / powf(omega_mid, beta)) * diff_dst[diff_data_d.off(mb, oc, oh, ow)];
         B *= src[data_d.off(mb, oc, oh, ow)];
         B *= (2.0f * alpha * beta) / kernel_size;
-        *d = A - B;
+        *d = static_cast<data_t>(A - B); // final cast down to data_t
     };
 
 #   pragma omp parallel for collapse(4) schedule(static)

--- a/src/cpu/ref_lrn.cpp
+++ b/src/cpu/ref_lrn.cpp
@@ -29,8 +29,6 @@ namespace cpu {
 template <impl::data_type_t data_type>
 void ref_lrn_fwd_t<data_type>::execute_forward() {
     using namespace alg_kind;
-    typedef float float_t;    // foo_traits<data_type>::float_t;
-    typedef double accsqr_t;  // foo_traits<data_type>::accsqr_t; //float may be OK for f32
 
     auto src = reinterpret_cast<const data_t *>(this->input_memory(0));
     auto dst = reinterpret_cast<data_t*>(this->memory(0));
@@ -45,16 +43,16 @@ void ref_lrn_fwd_t<data_type>::execute_forward() {
     const bool across_channels = conf_.desc()->alg_kind == lrn_across_channels;
 
     auto ker = [=](data_t *d, int mb, int oc, int oh, int ow) {
-        const double alpha = conf_.desc()->lrn_alpha;
+        const float alpha = static_cast<float>(conf_.desc()->lrn_alpha);
         const float beta = static_cast<float>(conf_.desc()->lrn_beta);
-        const double k = conf_.desc()->lrn_k;
+        const float k = static_cast<float>(conf_.desc()->lrn_k);
 
         const int size = conf_.desc()->local_size;
         const int CSIZE = across_channels ? size : 1;
         const int HWSIZE = size + 1 - CSIZE;
 
-        accsqr_t sum = 0;
-        int summands = across_channels ? size : size*size;
+        float sum = 0;
+        const int summands = across_channels ? size : size * size;
         for (int c = oc; c < oc + CSIZE; ++c) {
             if (c < (CSIZE - 1) / 2) continue;
             if (c >= C + (CSIZE - 1) / 2) continue;
@@ -64,18 +62,17 @@ void ref_lrn_fwd_t<data_type>::execute_forward() {
                 for (int w = ow; w < ow + HWSIZE; ++w) {
                     if (w < (HWSIZE - 1) / 2) continue;
                     if (w >= W + (HWSIZE - 1) / 2) continue;
-                    accsqr_t s = src[data_d.off(mb, c - (CSIZE - 1) / 2,
+                    const float s = src[data_d.off(mb, c - (CSIZE - 1) / 2,
                             h - (HWSIZE - 1) / 2, w - (HWSIZE - 1) / 2)];
                     sum += s * s;
                 }
             }
         }
-        const double fsum = k + alpha * sum / summands;
-        const data_t dsum = static_cast<data_t>(fsum);
+        sum = k + alpha * sum / summands;
         if (ws)
-            ws[ws_d.off(mb, oc, oh, ow)] = dsum; // for back prop (ok for integer data_t?)
-        d[0] = static_cast<data_t>( src[data_d.off(mb, oc, oh, ow)]
-                                    / powf((float)dsum, beta) );
+            ws[ws_d.off(mb, oc, oh, ow)] = static_cast<data_t>(sum);
+        d[0] = static_cast<data_t>(src[data_d.off(mb, oc, oh, ow)]
+                / powf(sum, beta));
     };
 
     const int MB = conf_.MB();
@@ -94,62 +91,59 @@ void ref_lrn_fwd_t<data_type>::execute_forward() {
 template <impl::data_type_t data_type>
 void ref_lrn_bwd_t<data_type>::execute_backward() {
     using namespace alg_kind;
-    typedef float float_t;    // foo_traits<data_type>::float_t;
-    typedef double accsqr_t;  // foo_traits<data_type>::accsqr_t; //float may be OK for f32
 
     auto src = reinterpret_cast<const data_t *>(this->input_memory(0));
     auto diff_dst = reinterpret_cast<const data_t *>(this->input_memory(1));
-    //auto ws = reinterpret_cast<data_t*>(this->memory(3)); // unused
     auto diff_src = reinterpret_cast<data_t*>(this->memory(0));
 
     const memory_desc_wrapper data_d(conf_.src_pd());
     const memory_desc_wrapper diff_data_d(conf_.diff_dst_pd());
-    //const memory_desc_wrapper ws_d(conf_.workspace_pd()); // unused
 
     const int MB = conf_.MB();
     const int C = conf_.C();
     const int H = conf_.H();
     const int W = conf_.W();
 
-    const float_t alpha = static_cast<float_t>(conf_.desc()->lrn_alpha);
-    const float_t beta = static_cast<float_t>(conf_.desc()->lrn_beta);
-    const float_t k = static_cast<float_t>(conf_.desc()->lrn_k);
+    const float alpha = static_cast<float>(conf_.desc()->lrn_alpha);
+    const float beta = static_cast<float>(conf_.desc()->lrn_beta);
+    const float k = static_cast<float>(conf_.desc()->lrn_k);
     const int kernel_size = conf_.desc()->local_size;
 
-    auto get_omega = [=](data_t c_k, int kernel_size, double alpha, int C,
-            const data_t *src, int n, int c, int h, int w) -> float_t {
-        accsqr_t sum = 0.0;
+    auto get_omega = [=](data_t c_k, int kernel_size, int C, const data_t *src,
+            int n, int c, int h, int w) -> float {
+        float sum = 0.0;
 
         int half_kernel_size = (kernel_size - 1) / 2;
         int c_start = (c < half_kernel_size) ? 0 : c - half_kernel_size;
         int c_end = c + kernel_size - half_kernel_size;
         c_end = c_end < C ? c_end : C;
         for (int i = c_start; i < c_end; ++i) {
-            const accsqr_t value = src[data_d.off(n, i, h, w)];
+            const float value = src[data_d.off(n, i, h, w)];
             sum += value * value;
         }
-        const auto fsum = sum * alpha / kernel_size;
-        return static_cast<float_t>(c_k + fsum);
+        return static_cast<float>(c_k + sum * alpha / kernel_size);
     };
 
     auto ker = [=](data_t *d, int mb, int oc, int oh, int ow) {
         int ks_start = kernel_size/2 > oc ? kernel_size/2 - oc : 0;
-        int ks_stop = C - oc <= kernel_size/2 ? C - oc + kernel_size/2 : kernel_size;
+        int ks_stop = C - oc <= kernel_size/2
+            ? C - oc + kernel_size/2 : kernel_size;
 
-        float_t A = 0, B = 0, omega_mid = 0;
-        // intermediate calcs data_t --> float_t : check if OK for integer data_t!
+        float A = 0, B = 0, omega_mid = 0;
+        // intermediate calcs data_t --> float (check if OK for int data_t)
         for (int ks = ks_start; ks < ks_stop; ks++) {
             int _t = oc + ks - (kernel_size/2);
-            const float_t omega = get_omega(k, kernel_size, alpha, C,
-                    src, mb, _t, oh, ow);
+            const float omega
+                = get_omega(k, kernel_size, C, src, mb, _t, oh, ow);
 
             if (ks == kernel_size/2) omega_mid = omega;
 
-            const float_t t = src[data_d.off(mb, _t, oh, ow)] / powf(omega, beta);
-            B +=  (1.0f / omega) * t * diff_dst[diff_data_d.off(mb, _t, oh, ow)];
+            float t = src[data_d.off(mb, _t, oh, ow)] / powf(omega, beta);
+            B += 1.0f / omega * t * diff_dst[diff_data_d.off(mb, _t, oh, ow)];
         }
 
-        A = (1.0f / powf(omega_mid, beta)) * diff_dst[diff_data_d.off(mb, oc, oh, ow)];
+        A = 1.0f / powf(omega_mid, beta)
+            * diff_dst[diff_data_d.off(mb, oc, oh, ow)];
         B *= src[data_d.off(mb, oc, oh, ow)];
         B *= (2.0f * alpha * beta) / kernel_size;
         *d = static_cast<data_t>(A - B); // final cast down to data_t

--- a/src/cpu/simple_reorder.hpp
+++ b/src/cpu/simple_reorder.hpp
@@ -375,8 +375,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                             + col * ostrides[3];
                         const auto i_idx = row * istrides[0]
                             + col * istrides[3];
-                        o[o_idx] = alpha * data_t<type_o>(i[i_idx])
-                            + (beta ? beta * o[o_idx] : 0);
+                        o[o_idx] = data_t<type_o>(alpha * i[i_idx]
+                            + (beta ? beta * o[o_idx] : 0));
                     }
                 }
             }
@@ -446,12 +446,12 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                             [w_groups + 1];
                     if (order_keep) {
                         o[ic * blksize + oc] =
-                            alpha * data_t<type_o>(i[_g_oihw_off])
-                            + (beta ? beta * o[ic * blksize + oc] : 0);
+                            data_t<type_o>(alpha * i[_g_oihw_off]
+                            + (beta ? beta * o[ic * blksize + oc] : 0));
                     } else {
                         o[_g_oihw_off] =
-                            alpha * data_t<type_o>(i[ic * blksize + oc])
-                            + (beta ? beta * o[_g_oihw_off] : 0);
+                            data_t<type_o>(alpha * i[ic * blksize + oc]
+                            + (beta ? beta * o[_g_oihw_off] : 0));
                     }
                 }
                 }
@@ -604,16 +604,12 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
             if (alpha == 1.0 && beta == 0.0) {
                 for (int ic = 0; ic < blksize; ++ic) {
                     for (int oc = 0; oc < blksize; ++oc) {
-                        const int o_idx = ic * blksize + oc;
-                        const int i_idx = oc * blksize + ic;
                         o[index_dst(ic,oc)] = data_t<type_o>(i[index_src(ic,oc)]);
                     }
                 }
             } else {
                 for (int ic = 0; ic < blksize; ++ic) {
                     for (int oc = 0; oc < blksize; ++oc) {
-                        const int o_idx = ic * blksize + oc;
-                        const int i_idx = oc * blksize + ic;
                         o[index_dst(ic,oc)] = data_t<type_o>(
                                 alpha * i[index_src(ic,oc)]
                                 + (beta ? beta * o[index_dst(ic,oc)] : 0));
@@ -677,8 +673,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     const int i_idx = oc * blksize + ic;
                     o[o_idx] = (alpha == 1.0 && beta == 0.0)
                         ? data_t<type_o>(i[i_idx])
-                        : alpha * data_t<type_o>(i[i_idx])
-                            + (beta ? beta * o[o_idx] : 0);
+                        : data_t<type_o>(alpha * i[i_idx]
+                            + (beta ? beta * o[o_idx] : 0));
                 }
             }
         };

--- a/tests/gtests/test_eltwise.cpp
+++ b/tests/gtests/test_eltwise.cpp
@@ -29,13 +29,12 @@ template <typename T, typename A> inline T relu_bwd(T dd, T s, A alpha) {
 }
 
 template <typename T> T tanh_fwd(T s) {
-    double e = ::exp(2*s); /* maybe replace with -2*s? */
+    const double e = ::exp(2*s); /* maybe replace with -2*s? */
     return static_cast<T>((e - 1.0) / (e + 1.0));
 }
 template <typename T> T tanh_bwd(T dd, T s) {
-    //T th = tanh_fwd(s);
-    double const e = ::exp(2*s); /* maybe replace with -2*s? */
-    double const th = ((e - 1) / (e + 1));
+    const double e = ::exp(2*s); /* maybe replace with -2*s? */
+    const double th = ((e - 1) / (e + 1));
     return static_cast<T>(dd * (1 - th * th));
 }
 

--- a/tests/gtests/test_eltwise.cpp
+++ b/tests/gtests/test_eltwise.cpp
@@ -21,27 +21,29 @@
 
 namespace mkldnn {
 
-template <typename T> T relu_fwd(T s, T alpha) {
-    return s > 0 ? s : s * alpha;
+template <typename T, typename A> inline T relu_fwd(T s, A alpha) {
+    return s > 0 ? s : static_cast<T>(s * alpha);
 }
-template <typename T> T relu_bwd(T dd, T s, T alpha) {
-    return s > 0 ? dd : dd * alpha;
+template <typename T, typename A> inline T relu_bwd(T dd, T s, A alpha) {
+    return s > 0 ? dd : static_cast<T>(dd * alpha);
 }
 
 template <typename T> T tanh_fwd(T s) {
-    T e = ::expf(2*s); /* maybe replace with -2*s? */
-    return (e - 1) / (e + 1);
+    double e = ::exp(2*s); /* maybe replace with -2*s? */
+    return static_cast<T>((e - 1.0) / (e + 1.0));
 }
 template <typename T> T tanh_bwd(T dd, T s) {
-    T th = tanh_fwd(s);
-    return dd * (1 - th * th);
+    //T th = tanh_fwd(s);
+    double const e = ::exp(2*s); /* maybe replace with -2*s? */
+    double const th = ((e - 1) / (e + 1));
+    return static_cast<T>(dd * (1 - th * th));
 }
 
 template <typename T, typename A> T elu_fwd(T s, A alpha) {
-    return s > 0 ? s : alpha * (::expf(s) - 1);
+    return s > 0 ? s : static_cast<T>(alpha * (::exp(s) - 1));
 }
 template <typename T, typename A> T elu_bwd(T dd, T s, A alpha) {
-    return static_cast<T>(dd * (s > 0 ? 1 : alpha * ::expf((float)s)));
+    return static_cast<T>(dd * (s > 0 ? 1 : alpha * ::exp(s)));
 }
 
 template <typename data_t>


### PR DESCRIPTION
- more int vs size_t issues
- simple_reorder has many changes where the conversion to data_t<type_o>
is done a little too early. 
- one case of moving the alpha,beta test
up a few lines in ker lambda ker (to mirror other cases).
- Also a couple of cases where intermediate calcs are forced to
float/double, and then finally converted to some data_t.
(some of these may need to be revisited for int data_t support, later,
 but at least the conversions are visible in the code for now.)

ref_eltwise decides to keep intermediate values as floating point.
... (oh, I think it slipped my mind to keep the corresponding gtests calcs with double )