### PR TITLE
Fix compile error about UNIT8_MAX not defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,9 @@ if(UNIX OR APPLE)
     endif()
 endif()
 
-# See https://stackoverflow.com/questions/986426
-# UNIT8_MAX is not part of C++ standard. Define theses macros to fit C++ standard.
+# UNIT8_MAX like macros are part of C99 standard and not C++ (see C99 standard 7.18.2 and 7.18.4)
 add_definitions(-D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS)
+
 if(WIN32)
     add_definitions(-DMKLDNN_DLL -DMKLDNN_DLL_EXPORTS)
     add_definitions(/MP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,9 @@ if(UNIX OR APPLE)
     endif()
 endif()
 
+# See https://stackoverflow.com/questions/986426
+# UNIT8_MAX is not part of C++ standard. Define theses macros to fit C++ standard.
+add_definitions(-D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS)
 if(WIN32)
     add_definitions(-DMKLDNN_DLL -DMKLDNN_DLL_EXPORTS)
     add_definitions(/MP)


### PR DESCRIPTION
UNIT8_MAX and similar macros are not part of C++ standard. Must define
__STDC_LIMIT_MACROS and __STDC_CONSTANT_MACROS before using that.

See https://stackoverflow.com/questions/986426/