### PR TITLE
Int promotion in benchdnn

### DIFF
--- a/tests/benchdnn/conv/conv.hpp
+++ b/tests/benchdnn/conv/conv.hpp
@@ -118,7 +118,7 @@ extern const char *skip_impl; /* NULL or "" means do not skip anything */
 extern bool allow_unimpl; /* true means do not treat unimplemented as error */
 extern const char *perf_template; /* performance output template */
 
-inline size_t src_off_f(const prb_t *p, int mb, int g, int ic, int ih, int iw)
+inline size_t src_off_f(const prb_t *p, size_t mb, size_t g, size_t ic, size_t ih, size_t iw)
 {
     return ((mb * p->ic + g * p->ic/p->g + ic) * p->ih + ih) * p->iw + iw;
 }
@@ -133,7 +133,7 @@ inline void inv_src_off_f(const prb_t *p, int off, int &mb, int &g, int &ic,
     assert(off == 0);
 }
 
-inline size_t wei_off_f(const prb_t *p, int g, int oc, int ic, int kh, int kw)
+inline size_t wei_off_f(const prb_t *p, size_t g, size_t oc, size_t ic, size_t kh, size_t kw)
 {
     return (((g * p->oc / p->g + oc) * p->ic / p->g + ic) * p->kh + kh) * p->kw
         + kw;
@@ -149,7 +149,7 @@ inline void inv_wei_off_f(const prb_t *p, int off, int &g, int &oc, int &ic,
     assert(off == 0);
 }
 
-inline size_t bia_off_f(const prb_t *p, int g, int oc) {
+inline size_t bia_off_f(const prb_t *p, size_t g, size_t oc) {
     return g * p->oc / p->g + oc;
 }
 
@@ -159,7 +159,7 @@ inline void inv_bia_off_f(const prb_t *p, int off, int &g, int &oc) {
     assert(off == 0);
 }
 
-inline size_t dst_off_f(const prb_t *p, int mb, int g, int oc, int oh, int ow)
+inline size_t dst_off_f(const prb_t *p, size_t mb, size_t g, size_t oc, size_t oh, size_t ow)
 {
     return ((mb * p->oc + g * p->oc/p->g + oc) * p->oh + oh) * p->ow + ow;
 }

--- a/tests/benchdnn/conv/conv.hpp
+++ b/tests/benchdnn/conv/conv.hpp
@@ -120,7 +120,8 @@ extern const char *perf_template; /* performance output template */
 
 inline size_t src_off_f(const prb_t *p, int mb, int g, int ic, int ih, int iw)
 {
-    return (((size_t)mb * p->ic + g * p->ic/p->g + ic) * p->ih + ih) * p->iw + iw;
+    return (((size_t)mb * p->ic + g * p->ic/p->g + ic) * p->ih + ih) * p->iw
+        + iw;
 }
 
 inline void inv_src_off_f(const prb_t *p, int off, int &mb, int &g, int &ic,
@@ -135,8 +136,8 @@ inline void inv_src_off_f(const prb_t *p, int off, int &mb, int &g, int &ic,
 
 inline size_t wei_off_f(const prb_t *p, int g, int oc, int ic, int kh, int kw)
 {
-    return ((((size_t)g * p->oc / p->g + oc) * p->ic / p->g + ic) * p->kh + kh) * p->kw
-        + kw;
+    return ((((size_t)g * p->oc / p->g + oc) * p->ic / p->g + ic) * p->kh + kh)
+        * p->kw + kw;
 }
 
 inline void inv_wei_off_f(const prb_t *p, int off, int &g, int &oc, int &ic,
@@ -161,7 +162,8 @@ inline void inv_bia_off_f(const prb_t *p, int off, int &g, int &oc) {
 
 inline size_t dst_off_f(const prb_t *p, int mb, int g, int oc, int oh, int ow)
 {
-    return (((size_t)mb * p->oc + g * p->oc/p->g + oc) * p->oh + oh) * p->ow + ow;
+    return (((size_t)mb * p->oc + g * p->oc/p->g + oc) * p->oh + oh) * p->ow
+        + ow;
 }
 
 inline void inv_dst_off_f(const prb_t *p, int off, int &mb, int &g, int &oc,

--- a/tests/benchdnn/conv/conv.hpp
+++ b/tests/benchdnn/conv/conv.hpp
@@ -118,9 +118,9 @@ extern const char *skip_impl; /* NULL or "" means do not skip anything */
 extern bool allow_unimpl; /* true means do not treat unimplemented as error */
 extern const char *perf_template; /* performance output template */
 
-inline size_t src_off_f(const prb_t *p, size_t mb, size_t g, size_t ic, size_t ih, size_t iw)
+inline size_t src_off_f(const prb_t *p, int mb, int g, int ic, int ih, int iw)
 {
-    return ((mb * p->ic + g * p->ic/p->g + ic) * p->ih + ih) * p->iw + iw;
+    return (((size_t)mb * p->ic + g * p->ic/p->g + ic) * p->ih + ih) * p->iw + iw;
 }
 
 inline void inv_src_off_f(const prb_t *p, int off, int &mb, int &g, int &ic,
@@ -133,9 +133,9 @@ inline void inv_src_off_f(const prb_t *p, int off, int &mb, int &g, int &ic,
     assert(off == 0);
 }
 
-inline size_t wei_off_f(const prb_t *p, size_t g, size_t oc, size_t ic, size_t kh, size_t kw)
+inline size_t wei_off_f(const prb_t *p, int g, int oc, int ic, int kh, int kw)
 {
-    return (((g * p->oc / p->g + oc) * p->ic / p->g + ic) * p->kh + kh) * p->kw
+    return ((((size_t)g * p->oc / p->g + oc) * p->ic / p->g + ic) * p->kh + kh) * p->kw
         + kw;
 }
 
@@ -149,8 +149,8 @@ inline void inv_wei_off_f(const prb_t *p, int off, int &g, int &oc, int &ic,
     assert(off == 0);
 }
 
-inline size_t bia_off_f(const prb_t *p, size_t g, size_t oc) {
-    return g * p->oc / p->g + oc;
+inline size_t bia_off_f(const prb_t *p, int g, int oc) {
+    return (size_t)g * p->oc / p->g + oc;
 }
 
 inline void inv_bia_off_f(const prb_t *p, int off, int &g, int &oc) {
@@ -159,9 +159,9 @@ inline void inv_bia_off_f(const prb_t *p, int off, int &g, int &oc) {
     assert(off == 0);
 }
 
-inline size_t dst_off_f(const prb_t *p, size_t mb, size_t g, size_t oc, size_t oh, size_t ow)
+inline size_t dst_off_f(const prb_t *p, int mb, int g, int oc, int oh, int ow)
 {
-    return ((mb * p->oc + g * p->oc/p->g + oc) * p->oh + oh) * p->ow + ow;
+    return (((size_t)mb * p->oc + g * p->oc/p->g + oc) * p->oh + oh) * p->ow + ow;
 }
 
 inline void inv_dst_off_f(const prb_t *p, int off, int &mb, int &g, int &oc,


### PR DESCRIPTION
Running benchdnn for tests that requires a lot of memory sometimes results in segfaults. The real issue is an integer overflow in several inlined functions that are used to calculate memory allocation size.