### PR TITLE
check for curl or wget availability in prepare_mkl script

### DIFF
--- a/scripts/prepare_mkl.sh
+++ b/scripts/prepare_mkl.sh
@@ -33,7 +33,15 @@ DST=`dirname $0`/../external
 mkdir -p $DST
 DST=`cd $DST;pwd`
 
-curl -L -o "${DST}/${MKLPACKAGE}" "$MKLURL"
+if [ -x "$(command -v curl)" ]; then
+  curl -L -o "${DST}/${MKLPACKAGE}" "$MKLURL"
+elif [ -x "$(command -v wget)" ]; then
+  wget -O "${DST}/${MKLPACKAGE}" "$MKLURL"
+else
+  echo "curl or wget not available"
+  exit 1
+fi
+
 if [ \! $? ]; then
   echo "Download from $MKLURL to $DST failed"
   exit 1


### PR DESCRIPTION
some systems do not have curl available, it will be nice to check for availability of either curl or wget.